### PR TITLE
get_config reads from .ini file

### DIFF
--- a/index.php
+++ b/index.php
@@ -126,6 +126,7 @@ class Admin {
 
 	}
 
+    //TODO: write to .ini file instead of .txt files
     function save_config() {
 		// No sanitizing necessary. It's just being written to a text file, so no security hole really.
 		// We'll sanitize them when retrieving the config vars

--- a/index.php
+++ b/index.php
@@ -142,9 +142,12 @@ class Admin {
 		}
 		$this->config = array();
 		while ( ( $file = strtolower( readdir($dir) ) ) != false ) {
-			if ( '.txt' == substr($file,-4) ) {
-				$this->config[ substr($file, 0, -4) ] = file_get_contents( $this->config_dir . $file );
-			}
+			if ( '.ini' == substr($file,-4) ) {
+                                $settings = parse_ini_file($this->config_dir.$file);
+                                foreach ($settings as $name => $value) {
+                                        $this->config[$name] = $value;
+                                }
+                        }
 		}
 		
 		//Todo: Sanitize config vars where necessary


### PR DESCRIPTION
get_config reads from .ini file only instead of from .txt files. save_config() still writes to .txt files.